### PR TITLE
Fix get by name

### DIFF
--- a/refreshpuddles.yml
+++ b/refreshpuddles.yml
@@ -20,7 +20,7 @@
     canonical_project_name: '{{ component.canonical_project_name }}'
     url: '{{ component.url }}'
     data: '{{ component.data }}'
-    topic_id: '{{ topic.topic.id }}'
+    topic_id: '{{ topic.id }}'
   register: create
 
 
@@ -54,7 +54,7 @@
 
   - name: Upload the component to the DCI control-server
     dci_component:
-      id: '{{ create.component.id }}'
+      id: '{{ create.id }}'
       path: '{{ component.canonical_project_name }}.tar'
 
 


### PR DESCRIPTION
Since we can't do get resources by name, the list + where name
returns directly the values without the resource prefix